### PR TITLE
Make it so we can re-transmit a model without having to resolve it

### DIFF
--- a/fff/learning/util/messages.py
+++ b/fff/learning/util/messages.py
@@ -17,14 +17,17 @@ class TorchMessage:
         self._pickle = None
 
     def __getstate__(self):
+        assert (self.model is None) ^ (self._pickle is None), "We have both a model and its pickled copy. That should never be"
         state = self.__dict__.copy()
-        # Save the model with pickle
-        model_pkl = BytesIO()
-        torch.save(self.model, model_pkl)
 
-        # Store it
-        state['model'] = None
-        state['_pickle'] = model_pkl.getvalue()
+        # Save the model with pickle if it isn't already serialized
+        if self._pickle is None:
+            model_pkl = BytesIO()
+            torch.save(self.model, model_pkl)
+
+            # Store it
+            state['model'] = None
+            state['_pickle'] = model_pkl.getvalue()
         return state
 
     def get_model(self, map_location: Union[str, torch.device] = 'cpu'):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 
-from _pytest.fixtures import fixture
 from ase.build import molecule
-
 from ase.db import connect
 from pytest import fixture
 

--- a/tests/test_model_msg.py
+++ b/tests/test_model_msg.py
@@ -1,0 +1,32 @@
+"""Tests dealing with the classes I use to transmit models between workers"""
+import pickle as pkl
+
+from pytest import fixture
+import numpy as np
+import torch
+
+from fff.learning.util.messages import TorchMessage
+
+
+@fixture()
+def model() -> torch.nn.Module:
+    return torch.nn.Linear(in_features=4, out_features=1)
+
+
+def test_pickle(model):
+    """Make sure we can pickle then get the model back"""
+
+    # Create the message
+    model_msg = TorchMessage(model)
+    assert model_msg._pickle is None
+
+    # Make a copy
+    model_msg_copy: TorchMessage = pkl.loads(pkl.dumps(model_msg))
+    assert model_msg._pickle is None  # Original should not hold on to the serialized version
+    assert model_msg_copy._pickle is not None  # The new one should not have a model yet
+    assert model_msg_copy.model is None
+
+    # Ensure that the new model yields the same result as the original
+    model_copy = model_msg_copy.get_model()
+    x = torch.Tensor([0, 1, 2, 4])
+    assert np.isclose(model(x).detach(), model_copy(x).detach()).all()

--- a/tests/test_model_msg.py
+++ b/tests/test_model_msg.py
@@ -30,3 +30,17 @@ def test_pickle(model):
     model_copy = model_msg_copy.get_model()
     x = torch.Tensor([0, 1, 2, 4])
     assert np.isclose(model(x).detach(), model_copy(x).detach()).all()
+
+
+def test_repickle(model):
+    """Make sure I can re-pickle a model without first resolving it"""
+
+    # Create a model_msg and then copy it twice
+    model_msg = TorchMessage(model)
+    model_msg_copy: TorchMessage = pkl.loads(pkl.dumps(model_msg))
+    model_msg_copy: TorchMessage = pkl.loads(pkl.dumps(model_msg_copy))
+
+    # Ensure that the new model yields the same result as the original
+    model_copy = model_msg_copy.get_model()
+    x = torch.Tensor([0, 1, 2, 4])
+    assert np.isclose(model(x).detach(), model_copy(x).detach()).all()


### PR DESCRIPTION
The `TorchMessage`  lets us send Torch models between systems. This PR fixes a bug that erases the model if we re-transmit the `TorchMessage` without first resolving the model it stores.