### PR TITLE
Measure coverage for subprocesses

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit = */tests/*
+concurrency = thread,multiprocessing


### PR DESCRIPTION
Do not check coverage for tests, add coverage for subprocesses/threads