### PR TITLE
Add option for returning only ground states structures from samplers

### DIFF
--- a/fff/sampling/mhm.py
+++ b/fff/sampling/mhm.py
@@ -19,6 +19,17 @@ _disallowed_kwargs = ['minima_traj']
 class MHMSampler(CalculatorBasedSampler):
     """Run minima hopping and return all minima"""
 
+    def __init__(self, return_minima_only: bool = False,
+                 scratch_dir: Path | None = None):
+        """
+
+        Args:
+            return_minima_only: Whether to only return minima produced at each step
+            scratch_dir: Location in which to store temporary files
+        """
+        super().__init__(scratch_dir=scratch_dir)
+        self.return_minima_only = return_minima_only
+
     def _run_sampling(self, atoms: ase.Atoms, steps: int, calc: Calculator, **kwargs) -> (ase.Atoms, list[ase.Atoms]):
         # Store where we started
         old_path = Path.cwd()
@@ -60,6 +71,6 @@ class MHMSampler(CalculatorBasedSampler):
                             new_steps.append(a)
                         all_steps.extend(new_steps[1:-1])  # Not the first or last
 
-                return minima[-1], minima[1:-1] + all_steps
+                return minima[-1], minima[1:-1] + ([] if self.return_minima_only else all_steps)
             finally:
                 os.chdir(old_path)  # Go back to where we started

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -47,6 +47,12 @@ def test_mctbp(cluster):
     assert isinstance(min_atoms, ase.Atoms)
     assert len(traj_atoms) > 4
 
+    # Test only returning the minima
+    mctbp.return_minima_only = True
+    _, traj_atoms = mctbp.run_sampling(cluster, 8, calc)
+    assert len(traj_atoms) == 9  # An initial relax plus 8 more
+    assert all(np.max(a.get_forces()) < 0.02 for a in traj_atoms)
+
 
 def test_mhm(cluster, tmpdir):
     calc = TTMCalculator()

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -64,4 +64,11 @@ def test_mhm(cluster, tmpdir):
     assert any(a.info['mhm-source'].startswith('md') for a in traj_atoms)
     assert any(a.info['mhm-source'].startswith('qn') for a in traj_atoms)
 
-    assert len(list(Path(tmpdir).glob("*"))) == 0
+    assert len(list(Path(tmpdir).glob("*"))) == 0, 'Did not clean up after self'
+
+    # Try with returning minima only
+    mhm.return_minima_only = True
+    _, traj_atoms, = mhm.run_sampling(cluster, 4, calc)
+
+    assert len(traj_atoms) <= 4  # Cannot find more than 4 unique minima
+    assert all(np.max(a.get_forces()) < 0.02 for a in traj_atoms)


### PR DESCRIPTION
This will, at least, simplify qualifying a FF's performance for global optimization