### PR TITLE
Fix assigning SchNetCalculator to a device

### DIFF
--- a/fff/sampling/base.py
+++ b/fff/sampling/base.py
@@ -39,7 +39,7 @@ class CalculatorBasedSampler(BaseSampler):
     """A sampler class which uses an ase :class:`~ase.calculators.calculator.Calculator` to generate energies"""
 
     def run_sampling(self, atoms: ase.Atoms, steps: int, calc: Calculator = None,
-                     device: str | None = None, **kwargs) -> (ase.Atoms, list[ase.Atoms]):
+                     device: str = 'cpu', **kwargs) -> (ase.Atoms, list[ase.Atoms]):
         """Run a sampling method
 
         Args:

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -92,6 +92,7 @@ def test_ase(model, example_waters):
     atoms: ase.Atoms = example_waters[0]
 
     calc = SchnetCalculator(model)
+    assert calc.device == 'cpu'
     atoms.set_calculator(calc)
     forces = calc.get_forces(atoms)
     numerical_forces = calc.calculate_numerical_forces(atoms, d=1e-4)


### PR DESCRIPTION
I modified the calculator such that the model is always on the device set Calculator. Require changing the serializer and ensuring that a device of "None" is not allowed.